### PR TITLE
Add Nanopore support

### DIFF
--- a/seqspec/Cargo.toml
+++ b/seqspec/Cargo.toml
@@ -24,3 +24,4 @@ tokio = "1.41"
 tokio-util = "0.7"
 futures = "0.3"
 async-compression = { version = "0.4", features = ["gzip", "zstd", "tokio"] }
+editdistancek = "1.0"

--- a/seqspec/src/lib.rs
+++ b/seqspec/src/lib.rs
@@ -527,13 +527,13 @@ impl Assay {
 
                     let split_result = match read.strand {
                         Strand::Unstranded => {
-                            SegmentInfo::split_auto_rc(&fwd_info, &record, 0.2, 0.2)
+                            SegmentInfo::split_auto_rc(&fwd_info, &record, 0.2, 0.2, 0.0)
                         }
-                        Strand::Pos => fwd_info.split_with_score(&record, 0.2, 0.2),
+                        Strand::Pos => fwd_info.split_with_tolerance(&record, 0.2, 0.2, 0.0),
                         Strand::Neg => {
                             // For Neg strand, we still use forward layout but mark as reverse
                             // In practice, Neg strand reads should be handled at the assay level
-                            fwd_info.split_with_score(&record, 0.2, 0.2)
+                            fwd_info.split_with_tolerance(&record, 0.2, 0.2, 0.0)
                         }
                     };
 

--- a/seqspec/src/lib.rs
+++ b/seqspec/src/lib.rs
@@ -567,13 +567,11 @@ pub enum Modality {
     Protein,
     ATAC,
     Crispr,
-    HiC
 }
 
 impl Modality {
     pub fn from_str_case_insensitive(s: &str) -> Option<Self> {
         match s.to_uppercase().as_str() {
-            "HIC" => Some(Modality::HiC),
             "RNA" => Some(Modality::RNA),
             "ATAC" => Some(Modality::ATAC),
             "PROTEIN" => Some(Modality::Protein),
@@ -610,7 +608,6 @@ impl FromStr for Modality {
             "tag" => Ok(Modality::Tag),
             "protein" => Ok(Modality::Protein),
             "atac" => Ok(Modality::ATAC),
-            "hic" => Ok(Modality::HiC),
             "crispr" => Ok(Modality::Crispr),
             _ => bail!("Invalid modality: {}", s),
         }
@@ -626,7 +623,6 @@ impl std::fmt::Display for Modality {
             Modality::Protein => "protein",
             Modality::ATAC => "atac",
             Modality::Crispr => "crispr",
-            Modality::HiC => "hic",
         };
         write!(f, "{}", s)
     }

--- a/seqspec/src/lib.rs
+++ b/seqspec/src/lib.rs
@@ -557,11 +557,13 @@ pub enum Modality {
     Protein,
     ATAC,
     Crispr,
+    HiC
 }
 
 impl Modality {
     pub fn from_str_case_insensitive(s: &str) -> Option<Self> {
         match s.to_uppercase().as_str() {
+            "HIC" => Some(Modality::HiC),
             "RNA" => Some(Modality::RNA),
             "ATAC" => Some(Modality::ATAC),
             "PROTEIN" => Some(Modality::Protein),
@@ -598,6 +600,7 @@ impl FromStr for Modality {
             "tag" => Ok(Modality::Tag),
             "protein" => Ok(Modality::Protein),
             "atac" => Ok(Modality::ATAC),
+            "hic" => Ok(Modality::HiC),
             "crispr" => Ok(Modality::Crispr),
             _ => bail!("Invalid modality: {}", s),
         }
@@ -613,6 +616,7 @@ impl std::fmt::Display for Modality {
             Modality::Protein => "protein",
             Modality::ATAC => "atac",
             Modality::Crispr => "crispr",
+            Modality::HiC => "hic",
         };
         write!(f, "{}", s)
     }

--- a/seqspec/src/read.rs
+++ b/seqspec/src/read.rs
@@ -1,7 +1,7 @@
 mod segment;
 use crate::region::Region;
 use crate::Modality;
-pub use segment::{Segment, SegmentInfo, SegmentInfoElem, SplitError, SplitResult};
+pub use segment::{Segment, SegmentInfo, SegmentInfoElem, SplitAutoRcBothResult, SplitError, SplitResult};
 
 use anyhow::{bail, Result};
 use file_download::download::Downloader;

--- a/seqspec/src/read/segment.rs
+++ b/seqspec/src/read/segment.rs
@@ -395,6 +395,11 @@ impl SegmentInfo {
     }
 
     /// Split by trying both forward and reverse segment layouts and return the best-scoring result.
+    ///
+    /// Selection priority:
+    /// 1. More barcode segments extracted (structural completeness for single-cell)
+    /// 2. More target/genomic segments extracted
+    /// 3. Fewer mismatches
     pub fn split_auto_rc<'a>(
         fwd_info: &'a SegmentInfo,
         rev_info: &'a SegmentInfo,

--- a/seqspec_templates/bd.yaml
+++ b/seqspec_templates/bd.yaml
@@ -1,0 +1,202 @@
+seqspec_version: 0.3.0
+assay_id: BD-Rhapsody-EB
+name: BD-Rhapsody-EB
+doi: https://scomix.bd.com/hc/en-us/articles/6990647359501-Rhapsody-WTA-Demo-Datasets-with-Enhanced-Cell-Capture-Beads
+date: 31 August 2022
+description: BD Rhapsody WTA is a nanowell-based commercial system that uses a split-pool
+  (Enahnced Beads-v2) approach to generate oligos on magnetic beads.
+modalities:
+- rna
+lib_struct: https://teichlab.github.io/scg_lib_structs/methods_html/BD_Rhapsody.html
+sequence_protocol: Illumina
+sequence_kit: []
+library_protocol: []
+library_kit: []
+sequence_spec:
+- !Read
+  read_id: R1
+  name: Read 1
+  modality: rna
+  primer_id: truseq_r1
+  min_len: 1
+  max_len: 250
+  strand: pos
+- !Read
+  read_id: R2
+  name: Read 2
+  modality: rna
+  primer_id: truseq_r2
+  min_len: 1
+  max_len: 250
+  strand: neg
+library_spec:
+- region_id: rna
+  region_type: rna
+  name: rna
+  sequence_type: joined
+  sequence: AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCTNNNNNNNNNGTGANNNNNNNNNGACANNNNNNNNNXXXXXXXXXXAGATCGGAAGAGCACACGTCTGAACTCCAGTCACNNNNNNNNATCTCGTATGCCGTCTTCTGCTTG
+  min_len: 169
+  max_len: 366
+  onlist: null
+  regions:
+  - region_id: illumina_p5
+    region_type: illumina_p5
+    name: illumina_p5
+    sequence_type: fixed
+    sequence: AATGATACGGCGACCACCGAGATCTACAC
+    min_len: 29
+    max_len: 29
+    onlist: null
+    regions: []
+  - region_id: truseq_r1
+    region_type: truseq_read1
+    name: truseq_r1
+    sequence_type: fixed
+    sequence: TCTTTCCCTACACGACGCTCTTCCGATCT
+    min_len: 29
+    max_len: 29
+    onlist: null
+    regions: []
+  - region_id: vb
+    region_type: linker
+    name: vb
+    sequence_type: onlist
+    sequence: ''
+    min_len: 0
+    max_len: 3
+    onlist:
+      file_id: vb_onlist.txt
+      filename: vb_onlist.txt
+      filetype: ''
+      filesize: 0
+      url: ''
+      urltype: local
+      md5: ''
+    regions: []
+  - region_id: cls1
+    region_type: barcode
+    name: cls1
+    sequence_type: onlist
+    sequence: NNNNNNNNN
+    min_len: 9
+    max_len: 9
+    onlist:
+      file_id: barcode1_clean.txt
+      filename: barcode1_clean.txt
+      filetype: 'txt'
+      filesize: 0
+      url: 'https://osf.io/download/4ygx2/'
+      urltype: https
+      md5: ''
+    regions: []
+  - region_id: linker1
+    region_type: linker
+    name: linker1
+    sequence_type: fixed
+    sequence: GTGA
+    min_len: 4
+    max_len: 4
+    onlist: null
+    regions: []
+  - region_id: cls2
+    region_type: barcode
+    name: cls2
+    sequence_type: onlist
+    sequence: NNNNNNNNN
+    min_len: 9
+    max_len: 9
+    onlist:
+      file_id: barcode2_clean.txt
+      filename: barcode2_clean.txt
+      filetype: 'txt'
+      filesize: 0
+      url: 'https://osf.io/download/y3nr4/'
+      urltype: https
+      md5: ''
+    regions: []
+  - region_id: linker2
+    region_type: linker
+    name: linker2
+    sequence_type: fixed
+    sequence: GACA
+    min_len: 4
+    max_len: 4
+    onlist: null
+    regions: []
+  - region_id: cls3
+    region_type: barcode
+    name: cls3
+    sequence_type: onlist
+    sequence: NNNNNNNNN
+    min_len: 9
+    max_len: 9
+    onlist:
+      file_id: barcode3_clean.txt
+      filename: barcode3_clean.txt
+      filetype: 'txt'
+      filesize: 0
+      url: https://osf.io/download/mhwgv/
+      urltype: https
+      md5: ''
+    regions: []
+  - region_id: umi
+    region_type: umi
+    name: umi
+    sequence_type: random
+    sequence: XXXXXXXX
+    min_len: 8
+    max_len: 8
+    onlist: null
+    regions: []
+  - region_id: polyT
+    region_type: poly_T
+    name: polyT
+    sequence_type: random
+    sequence: X
+    min_len: 1
+    max_len: 98
+    onlist: null
+    regions: []
+  - region_id: cdna
+    region_type: cdna
+    name: cdna
+    sequence_type: random
+    sequence: X
+    min_len: 1
+    max_len: 98
+    onlist: null
+    regions: []
+  - region_id: truseq_r2
+    region_type: truseq_read2
+    name: truseq_r2
+    sequence_type: fixed
+    sequence: AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC
+    min_len: 34
+    max_len: 34
+    onlist: null
+    regions: []
+  - region_id: sample_index
+    region_type: index7
+    name: sample_index
+    sequence_type: onlist
+    sequence: NNNNNNNN
+    min_len: 8
+    max_len: 8
+    onlist:
+      file_id: sample_index_onlist.txt
+      filename: sample_index_onlist.txt
+      filetype: ''
+      filesize: 0
+      url: ''
+      urltype: local
+      md5: ''
+    regions: []
+  - region_id: illumina_p7
+    region_type: illumina_p7
+    name: illumina_p7
+    sequence_type: fixed
+    sequence: ATCTCGTATGCCGTCTTCTGCTTG
+    min_len: 24
+    max_len: 24
+    onlist: null
+    regions: []


### PR DESCRIPTION
In Nanopore ATAC and Hi-C sequencing, reads from the same library can map to either the forward or reverse strand. To handle this, this commit introduces an `Unstranded` mark in `seqspec`. 

Key changes include:
1. Two-Phase Parsing: If marked as unstranded, the parser will evaluate both forward and reverse orientations. 
2. Barcode Rescue: Because a single Nanopore read can contain both forward and backward linkers simultaneously, the parser now returns both results if both orientations parse successfully, ensuring we can rescue barcodes in downstream task.
3. Indel Tolerance: Added bounded edit-distance logic to account for the high insertion/deletion error rates characteristic of scNanopore sequencing.
4. Algorithmic Optimization: Refactored the anchor search by replacing the KMP algorithm with a sliding window approach, which I find benchmarked at 2x faster in stress tests.

TODO: 
- Develop a Levenshtein-based barcode correction algorithm, as Nanopore barcodes are also highly susceptible to indels. I have implement this in hic-tailor, but I don't have time to implement for precellar now.

This strategy can retrieve 96% barcode in a normal single nanopore datasets.